### PR TITLE
libalarm: make cookie_t int32_t

### DIFF
--- a/src/alarmclient.c
+++ b/src/alarmclient.c
@@ -2633,7 +2633,7 @@ alarmclient_handle_del_event(char *args)
 {
   cookie_t cookie = alarmclient_string_to_cookie(args);
   int      error  = alarmd_event_del(cookie);
-  alarmclient_emitf("DEL %ld -> %s\n", cookie, error ? "ERR" : "OK");
+  alarmclient_emitf("DEL %d -> %s\n", cookie, error ? "ERR" : "OK");
 }
 
 /* ------------------------------------------------------------------------- *
@@ -2817,7 +2817,7 @@ alarmclient_handle_get_event(char *args)
   cookie_t cookie = alarmclient_string_to_cookie(args);
   alarm_event_t *event = alarmd_event_get(cookie);
 
-  alarmclient_emitf("GET %ld -> %s\n", cookie, event ? "OK" : "ERR");
+  alarmclient_emitf("GET %d -> %s\n", cookie, event ? "OK" : "ERR");
 
   if( event != 0 )
   {
@@ -2851,7 +2851,7 @@ alarmclient_handle_list_events(int verbose)
   {
     for( size_t i = 0; cookie && cookie[i]; ++i )
     {
-      alarmclient_emitf("[%03ld]\n", cookie[i]);
+      alarmclient_emitf("[%03d]\n", cookie[i]);
     }
   }
   else
@@ -2885,14 +2885,14 @@ alarmclient_handle_list_events(int verbose)
 
         snprintf(stamp, sizeof stamp, "%s (T%s)", date, secs);
 
-        alarmclient_emitf("[%03ld] %-36s %s\n", cookie[i], stamp, ident);
+        alarmclient_emitf("[%03d] %-36s %s\n", cookie[i], stamp, ident);
       }
     }
     else
     {
       for( size_t i = 0; i < n; ++i )
       {
-        alarmclient_emitf("[%03ld]  ", cookie[i]);
+        alarmclient_emitf("[%03d]  ", cookie[i]);
         alarmclient_event_show(event[i]);
       }
     }
@@ -2923,7 +2923,7 @@ alarmclient_handle_clear_events(void)
   else for( size_t i = 0; cookie[i]; ++i )
   {
     int rc = alarmd_event_del(cookie[i]);
-    alarmclient_emitf("DEL %ld -> %s\n", cookie[i], rc ? "ERR" : "OK");
+    alarmclient_emitf("DEL %d -> %s\n", cookie[i], rc ? "ERR" : "OK");
   }
   free(cookie);
 }
@@ -3021,7 +3021,7 @@ alarmclient_handle_new_event(char *args)
   }
   if( cookie > 0 )
   {
-    alarmclient_emitf("ADD -> %ld\n", cookie);
+    alarmclient_emitf("ADD -> %d\n", cookie);
   }
   else
   {
@@ -3204,7 +3204,7 @@ alarmclient_handle_add_trackable_event(char *args, int show)
   {
     if( (cookie = alarmd_event_update(eve)) > 0 )
     {
-      alarmclient_emitf("UPDATE -> %ld\n", cookie);
+      alarmclient_emitf("UPDATE -> %d\n", cookie);
     }
     else
     {
@@ -3215,7 +3215,7 @@ alarmclient_handle_add_trackable_event(char *args, int show)
   {
     if( (cookie = alarmd_event_add(eve)) > 0 )
     {
-      alarmclient_emitf("ADD -> %ld\n", cookie);
+      alarmclient_emitf("ADD -> %d\n", cookie);
     }
     else
     {

--- a/src/ipc_systemui.c
+++ b/src/ipc_systemui.c
@@ -35,6 +35,8 @@
 # include <stdlib.h>
 #endif
 
+#include <glib.h>
+
 static void (*systemui_ack_callback)(dbus_int32_t *vec, int cnt) = 0;
 
 static const char *(*systemui_service_callback)(void) = 0;
@@ -180,7 +182,7 @@ ipc_systemui_query_dialog(DBusConnection *conn)
 static void
 systemui_ack_open(DBusPendingCall *pending, void *user_data)
 {
-  cookie_t cookie = (cookie_t)user_data;
+  cookie_t cookie = (cookie_t)GPOINTER_TO_UINT(user_data);
   int      result = 0;
 
   DBusMessage *rsp = dbus_pending_call_steal_reply(pending);
@@ -228,7 +230,7 @@ systemui_ack_open(DBusPendingCall *pending, void *user_data)
 static void
 systemui_ack_close(DBusPendingCall *pending, void *user_data)
 {
-  cookie_t cookie = (cookie_t)user_data;
+  cookie_t cookie = (cookie_t)GPOINTER_TO_UINT(user_data);
   int      result = 0;
 
   DBusMessage *rsp = dbus_pending_call_steal_reply(pending);
@@ -279,7 +281,7 @@ systemui_open_dialog(DBusConnection *conn, cookie_t cookie)
   cookie &= ~MORE_BIT;
 
   return dbusif_method_call_async(conn,
-                                  systemui_ack_open, (void*)cookie,0,
+                                  systemui_ack_open, GUINT_TO_POINTER(cookie),0,
                                   systemui_service_name(),
                                   SYSTEMUI_REQUEST_PATH,
                                   SYSTEMUI_REQUEST_IF,
@@ -301,7 +303,7 @@ systemui_close_dialog(DBusConnection *conn, cookie_t cookie)
   cookie &= ~MORE_BIT;
 
   return dbusif_method_call_async(conn,
-                                  systemui_ack_close, (void*)cookie, 0,
+                                  systemui_ack_close, GUINT_TO_POINTER(cookie), 0,
                                   systemui_service_name(),
                                   SYSTEMUI_REQUEST_PATH,
                                   SYSTEMUI_REQUEST_IF,

--- a/src/libalarm.h
+++ b/src/libalarm.h
@@ -163,7 +163,7 @@ extern "C" {
 
 /** \brief Unique identifier type for the alarm events.
  **/
-typedef long cookie_t;
+typedef int32_t cookie_t;
 
 /* ------------------------------------------------------------------------- *
  * alarm_attr_t

--- a/src/queue.c
+++ b/src/queue.c
@@ -462,7 +462,7 @@ queue_event_set_state(alarm_event_t *self, unsigned state)
 
   if( previous != current )
   {
-    log_info("[%ld] TRANS: %s -> %s\n",
+    log_info("[%d] TRANS: %s -> %s\n",
              self->ALARMD_PRIVATE(cookie),
              queue_event_state_names[previous],
              queue_event_state_names[current]);
@@ -474,14 +474,14 @@ queue_event_set_state(alarm_event_t *self, unsigned state)
   }
   else if( current != state )
   {
-    log_warning("[%ld] TRANS: %s -> %s - BLOCKED\n",
+    log_warning("[%d] TRANS: %s -> %s - BLOCKED\n",
               self->ALARMD_PRIVATE(cookie),
               queue_event_state_names[previous],
               queue_event_state_names[state]);
   }
   else if( current == ALARM_STATE_NEW )
   {
-    log_info("[%ld] TRANS: %s -> %s\n",
+    log_info("[%d] TRANS: %s -> %s\n",
              self->ALARMD_PRIVATE(cookie),
              queue_event_state_names[previous],
              queue_event_state_names[current]);

--- a/src/server.c
+++ b/src/server.c
@@ -1924,7 +1924,7 @@ server_handle_systemui_ack(cookie_t *vec, int cnt)
   for( int i = 0; i < cnt; ++i )
   {
     alarm_event_t *eve = queue_get_event(vec[i]);
-    log_debug("[%ld] ACK: event=%p\n", vec[i], eve);
+    log_debug("[%d] ACK: event=%p\n", vec[i], eve);
     if( eve != 0 )
     {
       queue_event_set_state(eve, ALARM_STATE_SYSUI_ACK);
@@ -1958,7 +1958,7 @@ server_handle_systemui_rsp(cookie_t cookie, int button)
 
   alarm_event_t *eve = queue_get_event(cookie);
 
-  log_info("rsp %ld -> %p (button=%d)\n", cookie, eve, button);
+  log_info("rsp %d -> %p (button=%d)\n", cookie, eve, button);
 
   if( eve != 0 )
   {
@@ -2776,11 +2776,11 @@ server_rethink_timechange(void)
 
         ticker_break_tm(old, &tm, tz ?: server_tz_prev);
         server_repr_tm(&tm, tz ?: server_tz_prev, trg, sizeof trg);
-        log_debug("[%ld] OLD: %s, at %+d\n", vec[i], trg, (int)(old - now));
+        log_debug("[%d] OLD: %s, at %+d\n", vec[i], trg, (int)(old - now));
 
         ticker_break_tm(use, &tm, tz ?: server_tz_curr);
         server_repr_tm(&tm, tz ?: server_tz_curr, trg, sizeof trg);
-        log_debug("[%ld] NEW: %s, at %+d\n", vec[i], trg, (int)(use - now));
+        log_debug("[%d] NEW: %s, at %+d\n", vec[i], trg, (int)(use - now));
 
         queue_event_set_trigger(eve, use);
         queue_event_set_state(eve, ALARM_STATE_NEW);


### PR DESCRIPTION
The assertion in src/server.c was failing on 64 bit systems, where
sizeof(dbus_int32_t) != sizeof(cookie_t)