### PR TITLE
Changed CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ CFLAGS   += -Wmissing-prototypes
 CFLAGS   += -std=c99
 CFLAGS   += -Os
 CFLAGS   += -g
-CFLAGS   += -Werror
+CFLAGS   += -Wno-error
+CFLAGS   += -fcommon
 
 LDFLAGS  += -g
 


### PR DESCRIPTION
The build was failing with the following error:

```
src/queue.c:419:5: error: array subscript 16 is above array bounds of 'const char * const[16]' [-Werror=array-bounds]
  419 |     log_debug("UNKNOWN TRANSITION: %s -> %s\n",
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  420 |               queue_event_state_names[previous],
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  421 |               queue_event_state_names[state]);
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/queue.c:60:20: note: while referencing 'queue_event_state_names'
   60 | const char * const queue_event_state_names[] =
      |                    ^~~~~~~~~~~~~~~~~~~~~~~
```