### PR TITLE
Fix "array-bounds' warning with gcc10

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -416,9 +416,8 @@ queue_event_set_state(alarm_event_t *self, unsigned state)
   switch( state )
   {
   default:
-    log_debug("UNKNOWN TRANSITION: %s -> %s\n",
-              queue_event_state_names[previous],
-              queue_event_state_names[state]);
+    log_debug("UNKNOWN TRANSITION: %s -> %u\n",
+              queue_event_state_names[previous], state);
     break;
 
   case ALARM_STATE_NEW:

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -53,7 +53,7 @@ struct strbuf_t
  * strbuftypetags  --  encoding control characters used with strbuf
  * ------------------------------------------------------------------------- */
 
-enum strbuftypetags
+typedef enum strbuftypetags
 {
   tag_error     = -1,
   tag_done      =  0,


### PR DESCRIPTION
Signed-off-by: Ivaylo Dimitrov <ivo.g.dimitrov.75@gmail.com>